### PR TITLE
Improving build perfomance as recommended:

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
+org.gradle.jvmargs=-Xmx2048m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
"To run dex in process, the Gradle daemon needs a larger heap. It currently has 910 MB.  For faster builds, increase the maximum heap size for the Gradle daemon to more than 2048M.
To do this set org.gradle.jvmargs=-Xmx2048m in the project gradle.properties"

Build time improved from 1m 4s to 25s

Before:
![screenshot from 2016-06-30 23 14 11](https://cloud.githubusercontent.com/assets/6980967/16540374/1c80659c-4039-11e6-91cd-81930710c177.png)

After:
![screenshot from 2016-06-30 23 16 03](https://cloud.githubusercontent.com/assets/6980967/16540373/1c7cd9d6-4039-11e6-9a68-ac03634623b9.png)

